### PR TITLE
correct domain for the town Isny im Allgäu

### DIFF
--- a/data/source/overrides.csv
+++ b/data/source/overrides.csv
@@ -2,3 +2,4 @@ Domain Name,Agency
 arbeitsagentur.de,Bundesagentur für Arbeit
 kkr.bund.de,Kompetenzzentrum für das Kassen- und Rechnungswesen des Bundes
 zoll.de,Bundesministerium der Finanzen
+stadt.isny.de,Stadt Isny im Allgäu


### PR DESCRIPTION
The domain `isny.de` leads to the tourist information of the town and area of Isny im Allgäu. If you want the administrative town Isny im Allgäu, you have to use `stadt.isny.de`.
